### PR TITLE
Adds setup.py for making pip installable PyPI package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+from setuptools import find_packages, setup
+
+setup(
+    name='tsadams',
+    version='0.1.0',
+    description='Unsupervised Time Series Anomaly Detection Model Selection',
+    url='https://github.com/mononitogoswami/tsad-model-selection',
+    author='Mononito Goswami',
+    author_email='mgoswami@cs.cmu.edu',
+    license='Apache 2.0',
+    packages=find_packages(exclude=['tests', 'configs']),
+    install_requires=['cvxopt',
+                      'cvxpy',
+                      'matplotlib',
+                      'networkx',
+                      'pandas',
+                      'patool',
+                      'setuptools',
+                      'scikit-learn',
+                      'statsmodels',
+                      'tqdm',
+                      ],
+    classifiers=[
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 3.10',
+    ],
+)


### PR DESCRIPTION
This pull request is to make the tsad-model-selection library uploadable to PyPI and pip installable.

Following [this guide](https://betterscientificsoftware.github.io/python-for-hpc/tutorials/python-pypi-packaging/), I have created the setup.py file for initializing the PyPI package. The steps remaining are to upload the distribution to PyPI under the author of the library's PyPI account.